### PR TITLE
Updated bukkit dependency

### DIFF
--- a/bukkit/pom.xml
+++ b/bukkit/pom.xml
@@ -72,11 +72,17 @@
         </plugins>
     </build>
 
+    <repositories>
+        <repository>
+            <id>spigot-repo</id>
+            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
+        </repository>
+    </repositories>
     <dependencies>
         <dependency>
             <groupId>org.bukkit</groupId>
             <artifactId>bukkit</artifactId>
-            <version>1.7.9-R0.2</version>
+            <version>1.10.2-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -18,8 +18,8 @@
 
     <repositories>
         <repository>
-            <id>bukkit-repo</id>
-            <url>http://repo.bukkit.org/content/groups/public/</url>
+            <id>spigot-repo</id>
+            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
         </repository>
         <repository>
             <id>oss-sonatype-snapshots</id>


### PR DESCRIPTION
Fixed build error when trying to compile BuycraftX:
- Updated bukkit to 1.10.2-R0.1-SNAPSHOT
- Changed repository to spigot repository.
