### PR TITLE
Fix JitPack builds

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+  - oraclejdk8


### PR DESCRIPTION
JitPack by default uses jdk1.8 unless you have a travis (or other supported ci) file in your repo. If this is detected then by default it uses the lowest jdk version it can find which in this case is 1.7, which causes the build to break due to the sponge module. By adding this file we can override JitPack to use the correct jdk version for the repo builds.