### PR TITLE
Added XuidPlaceholder for Nukkit

### DIFF
--- a/common/src/main/java/net/buycraft/plugin/execution/placeholder/XuidPlaceholder.java
+++ b/common/src/main/java/net/buycraft/plugin/execution/placeholder/XuidPlaceholder.java
@@ -1,0 +1,19 @@
+package net.buycraft.plugin.execution.placeholder;
+
+import net.buycraft.plugin.UuidUtil;
+import net.buycraft.plugin.data.QueuedCommand;
+import net.buycraft.plugin.data.QueuedPlayer;
+
+import java.util.regex.Pattern;
+
+public class XuidPlaceholder implements Placeholder {
+    private static final Pattern REPLACE_UUID = Pattern.compile("[{(<\\[]id[})>\\]]", Pattern.CASE_INSENSITIVE);
+
+    @Override
+    public String replace(String command, QueuedPlayer player, QueuedCommand queuedCommand) {
+        if (player.getUuid() == null) {
+            return command; // can't replace UUID for offline mode
+        }
+        return REPLACE_UUID.matcher(command).replaceAll(player.getUuid());
+    }
+}

--- a/nukkit/src/main/java/net/buycraft/plugin/nukkit/BuycraftPlugin.java
+++ b/nukkit/src/main/java/net/buycraft/plugin/nukkit/BuycraftPlugin.java
@@ -15,6 +15,7 @@ import net.buycraft.plugin.execution.DuePlayerFetcher;
 import net.buycraft.plugin.execution.placeholder.NamePlaceholder;
 import net.buycraft.plugin.execution.placeholder.PlaceholderManager;
 import net.buycraft.plugin.execution.placeholder.UuidPlaceholder;
+import net.buycraft.plugin.execution.placeholder.XuidPlaceholder;
 import net.buycraft.plugin.execution.strategy.CommandExecutor;
 import net.buycraft.plugin.execution.strategy.PostCompletedCommandsTask;
 import net.buycraft.plugin.execution.strategy.QueuedCommandExecutor;
@@ -123,7 +124,7 @@ public class BuycraftPlugin extends PluginBase {
 
         // Initialize placeholders.
         placeholderManager.addPlaceholder(new NamePlaceholder());
-        placeholderManager.addPlaceholder(new UuidPlaceholder());
+        placeholderManager.addPlaceholder(new XuidPlaceholder());
 
         // Queueing tasks.
         platform.executeAsyncLater(duePlayerFetcher = new DuePlayerFetcher(platform, configuration.isVerbose()), 1, TimeUnit.SECONDS);


### PR DESCRIPTION
Fixed bug.

```
java.lang.IllegalArgumentException: Not a valid Mojang UUID.
        at com.google.common.base.Preconditions.checkArgument(Preconditions.java:122)
        at net.buycraft.plugin.UuidUtil.mojangUuidToJavaUuid(UuidUtil.java:19)
        at net.buycraft.plugin.execution.placeholder.UuidPlaceholder.replace(UuidPlaceholder.java:17)
        at net.buycraft.plugin.execution.placeholder.PlaceholderManager.doReplace(PlaceholderManager.java:19)
        at net.buycraft.plugin.execution.strategy.QueuedCommandExecutor.run(QueuedCommandExecutor.java:52)
        at cn.nukkit.scheduler.TaskHandler.run(TaskHandler.java:99)
        at cn.nukkit.scheduler.ServerScheduler.runTasks(ServerScheduler.java:295)
        at cn.nukkit.scheduler.ServerScheduler.mainThreadHeartbeat(ServerScheduler.java:276)
        at cn.nukkit.Server.tick(Server.java:1080)
        at cn.nukkit.Server.tickProcessor(Server.java:846)
        at cn.nukkit.Server.start(Server.java:823)
        at cn.nukkit.Server.<init>(Server.java:506)
        at cn.nukkit.Nukkit.main(Nukkit.java:102)
```