### PR TITLE
12.0.1 fixes

### DIFF
--- a/bukkit-post-1.13/pom.xml
+++ b/bukkit-post-1.13/pom.xml
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>BuycraftX</artifactId>
         <groupId>net.buycraft</groupId>
-        <version>12.0.0</version>
+        <version>12.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/bukkit-post-1.13/src/main/java/net/buycraft/plugin/bukkit/BukkitBuycraftPlatform.java
+++ b/bukkit-post-1.13/src/main/java/net/buycraft/plugin/bukkit/BukkitBuycraftPlatform.java
@@ -1,14 +1,18 @@
 package net.buycraft.plugin.bukkit;
 
 import com.google.common.collect.ImmutableSet;
-import org.bukkit.Bukkit;
 import org.bukkit.Material;
-import org.bukkit.block.data.BlockData;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.material.MaterialData;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
 
 public class BukkitBuycraftPlatform extends BukkitBuycraftPlatformBase {
-    private static final ImmutableSet<Material> SIGN_MATERIALS = ImmutableSet.of(Material.SIGN, Material.WALL_SIGN);
+    private static final ImmutableSet<Material> SIGN_MATERIALS = ImmutableSet.copyOf(Arrays.stream(Material.values())
+            .filter(material -> !material.name().startsWith("LEGACY_"))
+            .filter(material -> material.name().endsWith("SIGN")) // 1.14 has multiple sign variants now
+            .filter(Material::isBlock)
+            .collect(Collectors.toSet()));
 
     public BukkitBuycraftPlatform(BuycraftPluginBase plugin) {
         super(plugin);
@@ -31,17 +35,17 @@ public class BukkitBuycraftPlatform extends BukkitBuycraftPlatformBase {
 
     @Override
     public ItemStack createItemFromMaterialString(String materialData) {
-        if(materialData == null || materialData.trim().length()<=0) return null;
+        if (materialData == null || materialData.trim().length() <= 0) return null;
 
         Material material;
 
-        if(materialData.contains("[")) {
+        if (materialData.contains("[")) {
             material = Material.matchMaterial(materialData.split("\\[")[0]);
         } else {
             material = Material.matchMaterial(materialData.split(":")[0]);
         }
 
-        if(material == null) return null;
+        if (material == null) return null;
         return new ItemStack(material);
     }
 

--- a/bukkit-pre-1.13/pom.xml
+++ b/bukkit-pre-1.13/pom.xml
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>BuycraftX</artifactId>
         <groupId>net.buycraft</groupId>
-        <version>12.0.0</version>
+        <version>12.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/bukkit-shared/pom.xml
+++ b/bukkit-shared/pom.xml
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>BuycraftX</artifactId>
         <groupId>net.buycraft</groupId>
-        <version>12.0.0</version>
+        <version>12.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/bukkit-shared/src/main/java/net/buycraft/plugin/bukkit/gui/CategoryViewGUI.java
+++ b/bukkit-shared/src/main/java/net/buycraft/plugin/bukkit/gui/CategoryViewGUI.java
@@ -310,7 +310,7 @@ public class CategoryViewGUI {
                     plugin.getServer().getScheduler().runTask(plugin, () -> categoryMenus.get(category.getId()).get(page - 1).open(player));
                 } else if (displayName.equals(ChatColor.AQUA + plugin.getI18n().get("next_page"))) {
                     plugin.getServer().getScheduler().runTask(plugin, () -> categoryMenus.get(category.getId()).get(page + 1).open(player));
-                } else if (stack.getType() == Material.BOOK_AND_QUILL) {
+                } else if (stack.getType() == plugin.getPlatform().getGUIViewAllMaterial()) {
                     if (parentId != null) {
                         plugin.getServer().getScheduler().runTask(plugin, () -> categoryMenus.get(parentId).get(0).open(player));
                     } else {

--- a/bukkit-shared/src/main/java/net/buycraft/plugin/bukkit/gui/CategoryViewGUI.java
+++ b/bukkit-shared/src/main/java/net/buycraft/plugin/bukkit/gui/CategoryViewGUI.java
@@ -186,6 +186,7 @@ public class CategoryViewGUI {
                 subcatPartition = Lists.partition(category.getSubcategories(), 45);
                 if (subcatPartition.size() - 1 >= page) {
                     List<Category> subcats = subcatPartition.get(page);
+                    subcats.sort(Comparator.comparingInt(Category::getOrder));
                     for (int i = 0; i < subcats.size(); i++) {
                         Category subcat = subcats.get(i);
 
@@ -206,6 +207,7 @@ public class CategoryViewGUI {
 
             if (packagePartition.size() - 1 >= page) {
                 List<Package> packages = packagePartition.get(page);
+                packages.sort(Comparator.comparingInt(Package::getOrder));
                 for (int i = 0; i < packages.size(); i++) {
                     Package p = packages.get(i);
 

--- a/bungeecord/pom.xml
+++ b/bungeecord/pom.xml
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>BuycraftX</artifactId>
         <groupId>net.buycraft</groupId>
-        <version>12.0.0</version>
+        <version>12.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>BuycraftX</artifactId>
         <groupId>net.buycraft</groupId>
-        <version>12.0.0</version>
+        <version>12.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/common/src/main/java/net/buycraft/plugin/BuyCraftAPI.java
+++ b/common/src/main/java/net/buycraft/plugin/BuyCraftAPI.java
@@ -56,6 +56,9 @@ public interface BuyCraftAPI {
                                 Response response = chain.proceed(chain.request());
                                 if (!response.isSuccessful()) {
                                     ResponseBody body = response.body();
+                                    if (body == null) {
+                                        throw new BuyCraftAPIException("Unknown error occurred whilst deserializing error object.", response.request(), response, "");
+                                    }
                                     String in = body.string();
                                     if (!Objects.equals(response.header("Content-Type"), "application/json")) {
                                         throw new BuyCraftAPIException("Unexpected content-type " + response.header("Content-Type"), response.request(), response, in);

--- a/common/src/main/java/net/buycraft/plugin/data/Category.java
+++ b/common/src/main/java/net/buycraft/plugin/data/Category.java
@@ -3,7 +3,7 @@ package net.buycraft.plugin.data;
 import com.google.common.collect.ImmutableList;
 import com.google.gson.annotations.SerializedName;
 
-import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 
@@ -36,9 +36,9 @@ public final class Category implements Comparable<Category> {
     }
 
     public void order() {
-        Collections.sort(packages);
+        packages.sort(Comparator.comparingInt(Package::getOrder));
         if (subcategories != null) {
-            Collections.sort(subcategories);
+            subcategories.sort(Comparator.comparingInt(Category::getOrder));
             for (Category category : subcategories) {
                 category.order();
             }

--- a/nukkit/pom.xml
+++ b/nukkit/pom.xml
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>BuycraftX</artifactId>
         <groupId>net.buycraft</groupId>
-        <version>12.0.0</version>
+        <version>12.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/plugin-shared/pom.xml
+++ b/plugin-shared/pom.xml
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>BuycraftX</artifactId>
         <groupId>net.buycraft</groupId>
-        <version>12.0.0</version>
+        <version>12.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/plugin-shared/src/main/java/net/buycraft/plugin/shared/Setup.java
+++ b/plugin-shared/src/main/java/net/buycraft/plugin/shared/Setup.java
@@ -20,8 +20,8 @@ public final class Setup {
 
     public static OkHttpClient.Builder okhttpBuilder() {
         return new OkHttpClient.Builder()
-                .connectTimeout(3, TimeUnit.SECONDS)
-                .writeTimeout(5, TimeUnit.SECONDS)
+                .connectTimeout(6, TimeUnit.SECONDS)
+                .writeTimeout(7, TimeUnit.SECONDS)
                 .readTimeout(10, TimeUnit.SECONDS)
                 .dns(new Ipv4PreferDns())
                 .proxySelector(ProxySelector.getDefault() == null ? FakeProxySelector.INSTANCE : ProxySelector.getDefault());

--- a/plugin-shared/src/main/java/net/buycraft/plugin/shared/config/BuycraftI18n.java
+++ b/plugin-shared/src/main/java/net/buycraft/plugin/shared/config/BuycraftI18n.java
@@ -1,5 +1,7 @@
 package net.buycraft.plugin.shared.config;
 
+import com.google.common.base.Joiner;
+
 import java.io.IOException;
 import java.io.Reader;
 import java.nio.charset.StandardCharsets;
@@ -15,7 +17,12 @@ public class BuycraftI18n {
     private ResourceBundle userBundle;
 
     public BuycraftI18n(Locale locale) {
-        bundle = ResourceBundle.getBundle("buycraftx_messages", locale);
+        try {
+            bundle = ResourceBundle.getBundle("buycraftx_messages", locale,
+                    BuycraftI18n.class.getClassLoader());
+        } catch (Exception e) {
+            new RuntimeException("Failed to load i18n files! Will be using message ids as a replacement", e).printStackTrace();
+        }
     }
 
     public void loadUserBundle(Path resource) throws IOException {
@@ -25,7 +32,11 @@ public class BuycraftI18n {
     }
 
     public String get(String message, Object... params) {
-        return MessageFormat.format(getBundleFor(message).getString(message), params);
+        try {
+            return MessageFormat.format(getBundleFor(message).getString(message), params);
+        } catch (Exception e) {
+            return "i18n:"+message + "(" + Joiner.on(", ").join(params) + ")";
+        }
     }
 
     public ResourceBundle getBundleFor(String message) {

--- a/pom.xml
+++ b/pom.xml
@@ -1,13 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>net.buycraft</groupId>
     <artifactId>BuycraftX</artifactId>
     <packaging>pom</packaging>
-    <version>12.0.0</version>
+    <version>12.0.1</version>
     <modules>
         <module>common</module>
         <module>bukkit-shared</module>

--- a/sponge/pom.xml
+++ b/sponge/pom.xml
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>BuycraftX</artifactId>
         <groupId>net.buycraft</groupId>
-        <version>12.0.0</version>
+        <version>12.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
- Fix leftover BOOK_AND_QUILL material call
- Increase timeout values to max that were used in last API class
- Attempt to pre handle the new 1.14 sign materials
- Enforce sorting using a specific comparator & re-sorting inside the GUI class
- Version bump