### PR TITLE
Add support for 1.17 push commands

### DIFF
--- a/bukkit-shared/src/main/java/net/buycraft/plugin/bukkit/httplistener/NettyInjector.java
+++ b/bukkit-shared/src/main/java/net/buycraft/plugin/bukkit/httplistener/NettyInjector.java
@@ -21,7 +21,25 @@ public abstract class NettyInjector {
     static {
         String packageName = Bukkit.getServer().getClass().getPackage().getName();
         NMS_VERSION = packageName.substring(packageName.lastIndexOf(".") + 1);
-        NMS_PACKAGE = "net.minecraft.server." + NMS_VERSION + ".";
+
+        if (getNmsVersion() != null && getNmsVersion() >= 17) {
+            NMS_PACKAGE = "net.minecraft.server.";
+        } else {
+            NMS_PACKAGE = "net.minecraft.server." + NMS_VERSION + ".";
+        }
+    }
+
+    private static Integer getNmsVersion() {
+        String packageName = Bukkit.getServer().getClass().getPackage().getName();
+        String nmsVersion = packageName.substring(packageName.lastIndexOf(".") + 1);
+
+        String[] nmsVersionParts = nmsVersion.split("_");
+
+        if (nmsVersionParts.length == 3) {
+            return Integer.parseInt(nmsVersionParts[1]);
+        }
+
+        return null;
     }
 
     // The temporary player factory
@@ -104,7 +122,15 @@ public abstract class NettyInjector {
             };
 
             // Get the current NetworkMananger list
-            Class networkManagerClass = Class.forName(NMS_PACKAGE + "NetworkManager");
+
+            Class networkManagerClass;
+
+            if (getNmsVersion() != null && getNmsVersion() >= 17) {
+                networkManagerClass = Class.forName("net.minecraft.network.NetworkManager");
+            } else {
+                networkManagerClass = Class.forName(NMS_PACKAGE + "NetworkManager");
+            }
+
             Field networkManagersField = Arrays.stream(serverConnection.getClass().getDeclaredFields())
                     .filter(field -> field.getType() == List.class && ((ParameterizedType) field.getGenericType()).getActualTypeArguments()[0] == networkManagerClass)
                     .findFirst()


### PR DESCRIPTION
In Minecraft 1.17 the package path for `net.minecraft.server.v1_16_R3.NetworkManager` is now simply `net.minecraft.network.NetworkManager`, likewise with the `MinecraftServer` class. As such, the reflection we're using no longer works because the classes don't exist. 