### PR TITLE
Updating for Velocity 3.0.0

### DIFF
--- a/velocity/pom.xml
+++ b/velocity/pom.xml
@@ -127,7 +127,7 @@
         <dependency>
             <groupId>com.velocitypowered</groupId>
             <artifactId>velocity-api</artifactId>
-            <version>1.0.0-SNAPSHOT</version>
+            <version>3.0.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/velocity/src/main/java/net/buycraft/plugin/velocity/BuycraftCommand.java
+++ b/velocity/src/main/java/net/buycraft/plugin/velocity/BuycraftCommand.java
@@ -3,9 +3,9 @@ package net.buycraft.plugin.velocity;
 import com.velocitypowered.api.command.Command;
 import com.velocitypowered.api.command.CommandSource;
 import net.buycraft.plugin.velocity.command.Subcommand;
-import net.kyori.text.TextComponent;
-import net.kyori.text.format.TextColor;
-import net.kyori.text.format.TextDecoration;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextDecoration;
 
 import java.util.Arrays;
 import java.util.LinkedHashMap;
@@ -22,7 +22,7 @@ public class BuycraftCommand implements Command {
     @Override
     public void execute(CommandSource sender, String[] args) {
         if (!sender.hasPermission("buycraft.admin")) {
-            sender.sendMessage(TextComponent.of(plugin.getI18n().get("no_permission")).color(TextColor.RED));
+            sender.sendMessage(Component.text(plugin.getI18n().get("no_permission")).color(NamedTextColor.RED));
             return;
         }
 
@@ -43,9 +43,9 @@ public class BuycraftCommand implements Command {
     }
 
     private void showHelp(CommandSource sender) {
-        sender.sendMessage(TextComponent.of(plugin.getI18n().get("usage")).color(TextColor.DARK_AQUA).decoration(TextDecoration.BOLD, true));
+        sender.sendMessage(Component.text(plugin.getI18n().get("usage")).color(NamedTextColor.DARK_AQUA).decoration(TextDecoration.BOLD, true));
         for (Map.Entry<String, Subcommand> entry : subcommandMap.entrySet()) {
-            sender.sendMessage(TextComponent.of("/tebex " + entry.getKey()).color(TextColor.GREEN).append(TextComponent.of(": " + entry.getValue().getDescription())));
+            sender.sendMessage(Component.text("/tebex " + entry.getKey()).color(NamedTextColor.GREEN).append(Component.text(": " + entry.getValue().getDescription())));
         }
     }
 

--- a/velocity/src/main/java/net/buycraft/plugin/velocity/BuycraftCommand.java
+++ b/velocity/src/main/java/net/buycraft/plugin/velocity/BuycraftCommand.java
@@ -1,6 +1,6 @@
 package net.buycraft.plugin.velocity;
 
-import com.velocitypowered.api.command.Command;
+import com.velocitypowered.api.command.SimpleCommand;
 import com.velocitypowered.api.command.CommandSource;
 import net.buycraft.plugin.velocity.command.Subcommand;
 import net.kyori.adventure.text.Component;
@@ -11,7 +11,7 @@ import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-public class BuycraftCommand implements Command {
+public class BuycraftCommand implements SimpleCommand {
     private final Map<String, Subcommand> subcommandMap = new LinkedHashMap<>();
     private final BuycraftPlugin plugin;
 

--- a/velocity/src/main/java/net/buycraft/plugin/velocity/BuycraftCommand.java
+++ b/velocity/src/main/java/net/buycraft/plugin/velocity/BuycraftCommand.java
@@ -20,12 +20,17 @@ public class BuycraftCommand implements SimpleCommand {
     }
 
     @Override
-    public void execute(CommandSource sender, String[] args) {
+    public void execute(Invocation invocation) {
+        
+        CommandSource sender = invocation.source();
+        
         if (!sender.hasPermission("buycraft.admin")) {
             sender.sendMessage(Component.text(plugin.getI18n().get("no_permission")).color(NamedTextColor.RED));
             return;
         }
-
+        
+        String[] args = invocation.arguments();
+        
         if (args.length == 0) {
             showHelp(sender);
             return;

--- a/velocity/src/main/java/net/buycraft/plugin/velocity/BuycraftPlugin.java
+++ b/velocity/src/main/java/net/buycraft/plugin/velocity/BuycraftPlugin.java
@@ -187,7 +187,7 @@ public class BuycraftPlugin {
         command.getSubcommandMap().put("info", new InformationSubcommand(this));
         command.getSubcommandMap().put("report", new ReportCommand(this));
         command.getSubcommandMap().put("coupon", new CouponSubcommand(this));
-        getServer().getCommandManager().register(command, "tebex", "buycraft");
+        getServer().getCommandManager().register("tebex", command, "buycraft");
 
         // Send data to Keen IO
         if (serverInformation != null) {

--- a/velocity/src/main/java/net/buycraft/plugin/velocity/VelocityBuycraftPlatform.java
+++ b/velocity/src/main/java/net/buycraft/plugin/velocity/VelocityBuycraftPlatform.java
@@ -45,7 +45,7 @@ public class VelocityBuycraftPlatform implements IBuycraftPlatform {
 
     @Override
     public void dispatchCommand(String command) {
-        plugin.getServer().getCommandManager().execute(plugin.getServer().getConsoleCommandSource(), command);
+        plugin.getServer().getCommandManager().executeAsync(plugin.getServer().getConsoleCommandSource(), command);
     }
 
     @Override

--- a/velocity/src/main/java/net/buycraft/plugin/velocity/command/CouponSubcommand.java
+++ b/velocity/src/main/java/net/buycraft/plugin/velocity/command/CouponSubcommand.java
@@ -4,8 +4,8 @@ import com.velocitypowered.api.command.CommandSource;
 import net.buycraft.plugin.data.Coupon;
 import net.buycraft.plugin.shared.util.CouponUtil;
 import net.buycraft.plugin.velocity.BuycraftPlugin;
-import net.kyori.text.TextComponent;
-import net.kyori.text.format.TextColor;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -22,7 +22,7 @@ public class CouponSubcommand implements Subcommand {
     @Override
     public void execute(CommandSource sender, String[] args) {
         if (args.length == 0) {
-            sender.sendMessage(TextComponent.of(plugin.getI18n().get("usage_coupon_subcommands")).color(TextColor.RED));
+            sender.sendMessage(Component.text(plugin.getI18n().get("usage_coupon_subcommands")).color(NamedTextColor.RED));
             return;
         }
 
@@ -34,7 +34,7 @@ public class CouponSubcommand implements Subcommand {
                 deleteCoupon(sender, args);
                 break;
             default:
-                sender.sendMessage(TextComponent.of(plugin.getI18n().get("usage_coupon_subcommands")).color(TextColor.RED));
+                sender.sendMessage(Component.text(plugin.getI18n().get("usage_coupon_subcommands")).color(NamedTextColor.RED));
                 break;
         }
     }
@@ -45,23 +45,23 @@ public class CouponSubcommand implements Subcommand {
         try {
             coupon = CouponUtil.parseArguments(stripped);
         } catch (Exception e) {
-            sender.sendMessage(TextComponent.of(plugin.getI18n().get("coupon_creation_arg_parse_failure", e.getMessage())).color(TextColor.RED));
+            sender.sendMessage(Component.text(plugin.getI18n().get("coupon_creation_arg_parse_failure", e.getMessage())).color(NamedTextColor.RED));
             return;
         }
 
         plugin.getPlatform().executeAsync(() -> {
             try {
                 plugin.getApiClient().createCoupon(coupon).execute().body();
-                sender.sendMessage(TextComponent.of(plugin.getI18n().get("coupon_creation_success", coupon.getCode())).color(TextColor.GREEN));
+                sender.sendMessage(Component.text(plugin.getI18n().get("coupon_creation_success", coupon.getCode())).color(NamedTextColor.GREEN));
             } catch (IOException e) {
-                sender.sendMessage(TextComponent.of(plugin.getI18n().get("generic_api_operation_error")).color(TextColor.RED));
+                sender.sendMessage(Component.text(plugin.getI18n().get("generic_api_operation_error")).color(NamedTextColor.RED));
             }
         });
     }
 
     private void deleteCoupon(final CommandSource sender, String[] args) {
         if (args.length != 2) {
-            sender.sendMessage(TextComponent.of(plugin.getI18n().get("no_coupon_specified")).color(TextColor.RED));
+            sender.sendMessage(Component.text(plugin.getI18n().get("no_coupon_specified")).color(NamedTextColor.RED));
             return;
         }
 
@@ -69,9 +69,9 @@ public class CouponSubcommand implements Subcommand {
         plugin.getPlatform().executeAsync(() -> {
             try {
                 plugin.getApiClient().deleteCoupon(code).execute().body();
-                sender.sendMessage(TextComponent.of(plugin.getI18n().get("coupon_deleted")).color(TextColor.GREEN));
+                sender.sendMessage(Component.text(plugin.getI18n().get("coupon_deleted")).color(NamedTextColor.GREEN));
             } catch (IOException e) {
-                sender.sendMessage(TextComponent.of(e.getMessage()).color(TextColor.RED));
+                sender.sendMessage(Component.text(e.getMessage()).color(NamedTextColor.RED));
             }
         });
     }

--- a/velocity/src/main/java/net/buycraft/plugin/velocity/command/ForceCheckSubcommand.java
+++ b/velocity/src/main/java/net/buycraft/plugin/velocity/command/ForceCheckSubcommand.java
@@ -2,8 +2,8 @@ package net.buycraft.plugin.velocity.command;
 
 import com.velocitypowered.api.command.CommandSource;
 import net.buycraft.plugin.velocity.BuycraftPlugin;
-import net.kyori.text.TextComponent;
-import net.kyori.text.format.TextColor;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
 
 public class ForceCheckSubcommand implements Subcommand {
     private final BuycraftPlugin plugin;
@@ -15,22 +15,22 @@ public class ForceCheckSubcommand implements Subcommand {
     @Override
     public void execute(CommandSource sender, String[] args) {
         if (args.length != 0) {
-            sender.sendMessage(TextComponent.of(plugin.getI18n().get("no_params")).color(TextColor.RED));
+            sender.sendMessage(Component.text(plugin.getI18n().get("no_params")).color(NamedTextColor.RED));
             return;
         }
 
         if (plugin.getApiClient() == null) {
-            sender.sendMessage(TextComponent.of(plugin.getI18n().get("need_secret_key")).color(TextColor.RED));
+            sender.sendMessage(Component.text(plugin.getI18n().get("need_secret_key")).color(NamedTextColor.RED));
             return;
         }
 
         if (plugin.getDuePlayerFetcher().inProgress()) {
-            sender.sendMessage(TextComponent.of(plugin.getI18n().get("already_checking_for_purchases")).color(TextColor.RED));
+            sender.sendMessage(Component.text(plugin.getI18n().get("already_checking_for_purchases")).color(NamedTextColor.RED));
             return;
         }
 
         plugin.getPlatform().executeAsync(() -> plugin.getDuePlayerFetcher().run(false));
-        sender.sendMessage(TextComponent.of(plugin.getI18n().get("forcecheck_queued")).color(TextColor.GREEN));
+        sender.sendMessage(Component.text(plugin.getI18n().get("forcecheck_queued")).color(NamedTextColor.GREEN));
     }
 
     @Override

--- a/velocity/src/main/java/net/buycraft/plugin/velocity/command/InformationSubcommand.java
+++ b/velocity/src/main/java/net/buycraft/plugin/velocity/command/InformationSubcommand.java
@@ -2,8 +2,8 @@ package net.buycraft.plugin.velocity.command;
 
 import com.velocitypowered.api.command.CommandSource;
 import net.buycraft.plugin.velocity.BuycraftPlugin;
-import net.kyori.text.TextComponent;
-import net.kyori.text.format.TextColor;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
 
 public class InformationSubcommand implements Subcommand {
     private final BuycraftPlugin plugin;
@@ -15,28 +15,28 @@ public class InformationSubcommand implements Subcommand {
     @Override
     public void execute(CommandSource sender, String[] args) {
         if (args.length != 0) {
-            sender.sendMessage(TextComponent.of(plugin.getI18n().get("no_params")).color(TextColor.RED));
+            sender.sendMessage(Component.text(plugin.getI18n().get("no_params")).color(NamedTextColor.RED));
             return;
         }
 
         if (plugin.getApiClient() == null) {
-            sender.sendMessage(TextComponent.of(plugin.getI18n().get("need_secret_key")).color(TextColor.RED));
+            sender.sendMessage(Component.text(plugin.getI18n().get("need_secret_key")).color(NamedTextColor.RED));
             return;
         }
 
         if (plugin.getServerInformation() == null) {
-            sender.sendMessage(TextComponent.of(plugin.getI18n().get("information_no_server")).color(TextColor.RED));
+            sender.sendMessage(Component.text(plugin.getI18n().get("information_no_server")).color(NamedTextColor.RED));
             return;
         }
 
-        sender.sendMessage(TextComponent.of(plugin.getI18n().get("information_title")).color(TextColor.GRAY));
-        sender.sendMessage(TextComponent.of(plugin.getI18n().get("information_server",
+        sender.sendMessage(Component.text(plugin.getI18n().get("information_title")).color(NamedTextColor.GRAY));
+        sender.sendMessage(Component.text(plugin.getI18n().get("information_server",
                 plugin.getServerInformation().getServer().getName(),
-                plugin.getServerInformation().getAccount().getName())).color(TextColor.GRAY));
-        sender.sendMessage(TextComponent.of(plugin.getI18n().get("information_currency",
-                plugin.getServerInformation().getAccount().getCurrency().getIso4217())).color(TextColor.GRAY));
-        sender.sendMessage(TextComponent.of(plugin.getI18n().get("information_domain",
-                plugin.getServerInformation().getAccount().getDomain())).color(TextColor.GRAY));
+                plugin.getServerInformation().getAccount().getName())).color(NamedTextColor.GRAY));
+        sender.sendMessage(Component.text(plugin.getI18n().get("information_currency",
+                plugin.getServerInformation().getAccount().getCurrency().getIso4217())).color(NamedTextColor.GRAY));
+        sender.sendMessage(Component.text(plugin.getI18n().get("information_domain",
+                plugin.getServerInformation().getAccount().getDomain())).color(NamedTextColor.GRAY));
     }
 
     @Override

--- a/velocity/src/main/java/net/buycraft/plugin/velocity/command/ReportCommand.java
+++ b/velocity/src/main/java/net/buycraft/plugin/velocity/command/ReportCommand.java
@@ -3,8 +3,8 @@ package net.buycraft.plugin.velocity.command;
 import com.velocitypowered.api.command.CommandSource;
 import net.buycraft.plugin.shared.util.ReportBuilder;
 import net.buycraft.plugin.velocity.BuycraftPlugin;
-import net.kyori.text.TextComponent;
-import net.kyori.text.format.TextColor;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
 
 import java.io.BufferedWriter;
 import java.io.IOException;
@@ -25,7 +25,7 @@ public class ReportCommand implements Subcommand {
 
     @Override
     public void execute(final CommandSource sender, String[] args) {
-        sender.sendMessage(TextComponent.of(plugin.getI18n().get("report_wait")).color(TextColor.YELLOW));
+        sender.sendMessage(Component.text(plugin.getI18n().get("report_wait")).color(NamedTextColor.YELLOW));
 
         plugin.getPlatform().executeAsync(() -> {
             InetSocketAddress listener = plugin.getServer().getBoundAddress();
@@ -45,9 +45,9 @@ public class ReportCommand implements Subcommand {
             String generated = builder.generate();
             try (BufferedWriter w = Files.newBufferedWriter(p, StandardCharsets.UTF_8, StandardOpenOption.CREATE_NEW)) {
                 w.write(generated);
-                sender.sendMessage(TextComponent.of(plugin.getI18n().get("report_saved", p.toAbsolutePath().toString())).color(TextColor.YELLOW));
+                sender.sendMessage(Component.text(plugin.getI18n().get("report_saved", p.toAbsolutePath().toString())).color(NamedTextColor.YELLOW));
             } catch (IOException e) {
-                sender.sendMessage(TextComponent.of(plugin.getI18n().get("report_cant_save")).color(TextColor.RED));
+                sender.sendMessage(Component.text(plugin.getI18n().get("report_cant_save")).color(NamedTextColor.RED));
                 plugin.getLogger().info(generated);
             }
         });

--- a/velocity/src/main/java/net/buycraft/plugin/velocity/command/SecretSubcommand.java
+++ b/velocity/src/main/java/net/buycraft/plugin/velocity/command/SecretSubcommand.java
@@ -4,8 +4,8 @@ import com.velocitypowered.api.command.CommandSource;
 import net.buycraft.plugin.BuyCraftAPI;
 import net.buycraft.plugin.data.responses.ServerInformation;
 import net.buycraft.plugin.velocity.BuycraftPlugin;
-import net.kyori.text.TextComponent;
-import net.kyori.text.format.TextColor;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
 
 import java.io.IOException;
 import java.util.logging.Level;
@@ -20,12 +20,12 @@ public class SecretSubcommand implements Subcommand {
     @Override
     public void execute(final CommandSource sender, final String[] args) {
         if (!sender.equals(plugin.getServer().getConsoleCommandSource())) {
-            sender.sendMessage(TextComponent.of(plugin.getI18n().get("secret_console_only")).color(TextColor.RED));
+            sender.sendMessage(Component.text(plugin.getI18n().get("secret_console_only")).color(NamedTextColor.RED));
             return;
         }
 
         if (args.length != 1) {
-            sender.sendMessage(TextComponent.of(plugin.getI18n().get("secret_need_key")).color(TextColor.RED));
+            sender.sendMessage(Component.text(plugin.getI18n().get("secret_need_key")).color(NamedTextColor.RED));
             return;
         }
 
@@ -35,7 +35,7 @@ public class SecretSubcommand implements Subcommand {
                 plugin.updateInformation(client);
             } catch (IOException e) {
                 plugin.getLogger().error("Unable to verify secret", e);
-                sender.sendMessage(TextComponent.of(plugin.getI18n().get("secret_does_not_work")).color(TextColor.RED));
+                sender.sendMessage(Component.text(plugin.getI18n().get("secret_does_not_work")).color(NamedTextColor.RED));
                 return;
             }
 
@@ -45,11 +45,11 @@ public class SecretSubcommand implements Subcommand {
             try {
                 plugin.saveConfiguration();
             } catch (IOException e) {
-                sender.sendMessage(TextComponent.of(plugin.getI18n().get("secret_cant_be_saved")).color(TextColor.RED));
+                sender.sendMessage(Component.text(plugin.getI18n().get("secret_cant_be_saved")).color(NamedTextColor.RED));
             }
 
-            sender.sendMessage(TextComponent.of(plugin.getI18n().get("secret_success",
-                    information.getServer().getName(), information.getAccount().getName())).color(TextColor.GREEN));
+            sender.sendMessage(Component.text(plugin.getI18n().get("secret_success",
+                    information.getServer().getName(), information.getAccount().getName())).color(NamedTextColor.GREEN));
             plugin.getPlatform().executeAsync(plugin.getDuePlayerFetcher());
         });
     }

--- a/velocity/src/main/java/net/buycraft/plugin/velocity/util/VersionCheck.java
+++ b/velocity/src/main/java/net/buycraft/plugin/velocity/util/VersionCheck.java
@@ -5,8 +5,8 @@ import com.velocitypowered.api.event.connection.PostLoginEvent;
 import net.buycraft.plugin.data.responses.Version;
 import net.buycraft.plugin.shared.util.VersionUtil;
 import net.buycraft.plugin.velocity.BuycraftPlugin;
-import net.kyori.text.TextComponent;
-import net.kyori.text.format.TextColor;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
 
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
@@ -50,7 +50,7 @@ public class VersionCheck {
     public void onPlayerJoin(final PostLoginEvent event) {
         if (event.getPlayer().hasPermission("buycraft.admin") && !upToDate) {
             plugin.getPlatform().executeAsyncLater(() ->
-                    event.getPlayer().sendMessage(TextComponent.of(plugin.getI18n().get("update_available", lastKnownVersion.getVersion())).color(TextColor.YELLOW)), 3, TimeUnit.SECONDS);
+                    event.getPlayer().sendMessage(Component.text(plugin.getI18n().get("update_available", lastKnownVersion.getVersion())).color(NamedTextColor.YELLOW)), 3, TimeUnit.SECONDS);
         }
     }
 


### PR DESCRIPTION
Good morning! I've been working on minor fixes for the Velocity portion of Buycraft. I've tested these changes locally by self-building, to which worked as expected. At this time, the current version of Buycraft for Velocity is non-functional under Velocity 3.0.0 conditions, these changes should solve this.

The main changes are as follows
- Changing the imports to Kyori Adventure API, see the [Velocity Migration Guide](https://velocitypowered.com/wiki/developers/porting-from-velocity-1/), section Removal of legacy dependencies
- Changing all instances of TextComponent.of to Component.text (TextComponent is deprecated in favour of Component.text)
- Changing all instances of TextColor to NamedTextColor (TextColor is now an RGB class and the old stuff was moved to NamedTextColor)

Many thanks :)